### PR TITLE
Fix player rotations

### DIFF
--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1073,7 +1073,7 @@ void func_80021DA8(void) {
 }
 
 void mtxf_translate_rotate(Mat4 dest, Vec3f pos, Vec3s orientation) {
-#if 0
+#if 1
     f32 sinX;// = sins(orientation[0]);
     f32 cosX;// = coss(orientation[0]);
     f32 sinY;// = sins(orientation[1]);


### PR DESCRIPTION
Apparently the order of applying the rotation matrices here is not what I expected. Since it's clearly not a hot function (only ever reested in rare situations), and we're trying to hurry for release, undo the acceleration here until I can sit down and work out on paper exactly what in god's name order his happening here.